### PR TITLE
Add asynchronous ByteStreamReader class

### DIFF
--- a/example/byte_stream_reader.dart
+++ b/example/byte_stream_reader.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:buffer/buffer.dart';
+
+/// Parse a packet from some fictional protocol.
+Future<Uint8List> getPayloadFrometworkPacket(Socket socket) async {
+  // Pipe the stream into the [ByteStreamReader].
+  var rdr = ByteStreamReader();
+  socket.pipe(rdr);
+
+  // Assume that in this protocol, every packet has a 12-byte header:
+  // * 0: 2 bytes indicating protocol version
+  // * 2: Additional flags
+  // * 3: Checksum = flags & version
+  // * 4: 8 bytes that indicate the length of the rest of the packet (payload).
+
+  // Let's read our data!.
+  var protocolVersion = await rdr.read(2).then((b) => b.readUint16());
+  var flags = await rdr.read(1).then((b) => b.readUint8());
+}
+

--- a/example/byte_stream_reader.dart
+++ b/example/byte_stream_reader.dart
@@ -19,5 +19,14 @@ Future<Uint8List> getPayloadFrometworkPacket(Socket socket) async {
   var protocolVersion = await rdr.readUint8();
   var flags = await rdr.readUint8();
   var checksum = await rdr.readUint16();
-}
 
+  // Validate the checksum.
+  if (checksum != (protocolVersion & flags)) {
+    throw FormatException(
+        'Invalid checksum $checksum; expected ${protocolVersion & flags}.');
+  }
+
+  // Return the rest of the packet.
+  var payloadLength = await rdr.readUint64();
+  return await rdr.consume(payloadLength);
+}

--- a/example/byte_stream_reader.dart
+++ b/example/byte_stream_reader.dart
@@ -10,13 +10,14 @@ Future<Uint8List> getPayloadFrometworkPacket(Socket socket) async {
   socket.pipe(rdr);
 
   // Assume that in this protocol, every packet has a 12-byte header:
-  // * 0: 2 bytes indicating protocol version
-  // * 2: Additional flags
-  // * 3: Checksum = flags & version
+  // * 0: 1 byte indicating protocol version
+  // * 1: Additional flags
+  // * 2: 2-byte checksum = flags & version
   // * 4: 8 bytes that indicate the length of the rest of the packet (payload).
 
   // Let's read our data!.
-  var protocolVersion = await rdr.read(2).then((b) => b.readUint16());
-  var flags = await rdr.read(1).then((b) => b.readUint8());
+  var protocolVersion = await rdr.readUint8();
+  var flags = await rdr.readUint8();
+  var checksum = await rdr.readUint16();
 }
 

--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
+export 'src/byte_stream_reader.dart';
 
 /// Read [stream] into a String.
 Future<String> readAsString(Stream<List<int>> stream, {Encoding encoding}) {

--- a/lib/src/byte_stream_reader.dart
+++ b/lib/src/byte_stream_reader.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:io';
+import 'dart:typed_data';
+import '../buffer.dart';
+
+/// Asynchronously reads data in from a stream of bytes, which may or may not be continuous.
+///
+/// Use this in cases where the size of incoming content is *unknown* at runtime,
+/// i.e. in a network protocol.
+class ByteStreamReader extends StreamConsumer<List<int>> {
+  final Queue<_ByteStreamReaderAwaiter> _awaiterQueue =
+      new DoubleLinkedQueue<_ByteStreamReaderAwaiter>();
+  final Queue<Uint8List> _byteQueue = new DoubleLinkedQueue<Uint8List>();
+
+  static Uint8List coerceUint8List(List<int> list) {
+    return list is Uint8List ? list : new Uint8List.fromList(list);
+  }
+
+  Future<Uint8List> read(int length) {
+    var trace = StackTrace.current;
+    // First, check if the top of the byte queue has enough bytes.
+    if (_byteQueue.isNotEmpty) {
+      var top = _byteQueue.first;
+
+      // If the number of bytes is the *exact* amount, pop it and return.
+      if (top.length == length) {
+        _byteQueue.removeFirst();
+        return new Future<Uint8List>.value(top);
+      }
+
+      // Or, if there is an excess of bytes,
+      // return it, but only keep the remainder on the stack.
+      else if (top.length > length) {
+        var remainder =
+            new Uint8List.view(top.buffer, top.offsetInBytes + length);
+        var out = new Uint8List.view(top.buffer, top.offsetInBytes, length);
+        _byteQueue.removeFirst();
+        if (remainder.isNotEmpty) _byteQueue.addFirst(remainder);
+        return new Future<Uint8List>.value(out);
+      }
+    }
+
+    // Otherwise, create an awaiter, and try to fill it up.
+    var awaiter = new _ByteStreamReaderAwaiter(trace, length);
+
+    // Ideally, we will have enough bytes available.
+    //
+    // Remove buffers from the top of the queue until we have enough bytes.
+    while (_byteQueue.isNotEmpty && awaiter.remaining > 0) {
+      var top = _byteQueue.first;
+
+      // If the amount is exactly the same, AND there are no bytes in the buffer,
+      // just return the buffer itself.
+      if (top.length == awaiter.remaining && awaiter.builder.isEmpty) {
+        return new Future<Uint8List>.value(_byteQueue.removeFirst());
+      }
+
+      // If the buffer has less than or equal to the required number of bytes,
+      // add it all and remove it.
+      else if (top.length <= awaiter.remaining) {
+        awaiter.builder.add(_byteQueue.removeFirst());
+      }
+
+      // Otherwise, add the necessary amount, and only leave
+      // the remainder on the queue.
+      else {
+        var remainder =
+            new Uint8List.view(top.buffer, top.offsetInBytes + length);
+        var out = new Uint8List.view(top.buffer, top.offsetInBytes, length);
+        _byteQueue.removeFirst();
+        if (remainder.isNotEmpty) _byteQueue.addFirst(remainder);
+        return new Future<Uint8List>.value(out);
+      }
+    }
+
+    // If the awaiter is full, just return its value.
+    if (awaiter.remaining <= 0) {
+      return new Future<Uint8List>.value(
+          coerceUint8List(awaiter.builder.takeBytes()));
+    }
+
+    // Otherwise, enqueue it until further notice.
+    _awaiterQueue.addLast(awaiter);
+    return awaiter.completer.future;
+  }
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) {
+    return stream.map(coerceUint8List).forEach((buf) {
+      int index = 0;
+
+      // Complete any possible awaiters.
+      while (_awaiterQueue.isNotEmpty && index < buf.length - 1) {
+        var top = _awaiterQueue.first;
+        //print(
+        //    'want ${top.remaining} from ${top.fillLength}; top: ${top.builder.toBytes()}, buf: $buf (${buf.hashCode})');
+        //print('buf as str: ${new String.fromCharCodes(buf)}');
+        //print('i = $index/${buf.length - 1}');
+
+        // Dump out enqueued bytes into awaiters.
+        while (_byteQueue.isNotEmpty && top.remaining > 0) {
+          var topBytes = _byteQueue.removeFirst();
+
+          if (topBytes.length <= top.remaining) {
+            top.builder.add(topBytes);
+          } else {
+            var length = top.remaining;
+            var remainder = new Uint8List.view(
+                topBytes.buffer, topBytes.offsetInBytes + length);
+            var out = new Uint8List.view(
+                topBytes.buffer, topBytes.offsetInBytes, length);
+            _byteQueue.removeFirst();
+            if (remainder.isNotEmpty) _byteQueue.addFirst(remainder);
+            return new Future<Uint8List>.value(out);
+          }
+        }
+
+        if (top.remaining == 0) {
+          _awaiterQueue.removeFirst();
+          top.completer.complete(coerceUint8List(top.builder.toBytes()));
+          continue;
+        }
+
+        // If this is the first entry being added, and it is the exact size, add it.
+        if (top.remaining == buf.length && top.builder.isEmpty) {
+          _awaiterQueue.removeFirst();
+          top.completer.complete(buf);
+          return null;
+        }
+
+        // If the buffer has >= the size, add the whole thing.
+        else if (top.remaining >= buf.length) {
+          //print(
+          //    'Dumping all! ${buf.length} byte(s) into ${top.remaining}/${top.fillLength}!!');
+          top.builder.add(buf);
+
+          // Remove the awaiter if it's completed.
+          if (top.remaining == 0) {
+            _awaiterQueue.removeFirst();
+            top.completer.complete(coerceUint8List(top.builder.toBytes()));
+          }
+
+          return null;
+        }
+
+        // Otherwise, only add what is necessary.
+        else {
+          var out =
+              new Uint8List.view(buf.buffer, buf.offsetInBytes, top.remaining);
+          //print('a awaiting ${top.remaining} from ${top.fillLength}; o: $out');
+          index += top.remaining;
+          top.builder.add(out);
+
+          // Remove the awaiter if it's completed.
+          if (top.remaining == 0) {
+            _awaiterQueue.removeFirst();
+            top.completer.complete(coerceUint8List(top.builder.toBytes()));
+            //print('boom');
+          } else {
+            buf = new Uint8List.view(buf.buffer, buf.offsetInBytes + index);
+          }
+
+          // Enqueue all leftover data.
+          if (index >= 0) {
+            var leftover =
+                new Uint8List.view(buf.buffer, buf.offsetInBytes + index);
+            buf = leftover;
+          }
+
+          //print('Index is now $index; buf is now $buf (${buf.hashCode})');
+        }
+      }
+
+      // Enqueue all leftover data.
+      //print('Final i: $index');
+      if (buf.isNotEmpty) {
+        var leftover = buf;
+        //print('Leftover: $leftover (${new String.fromCharCodes(leftover)})');
+        _byteQueue.addLast(leftover);
+      }
+    });
+  }
+
+  @override
+  Future close() async {
+    while (_awaiterQueue.isNotEmpty) {
+      var awaiter = _awaiterQueue.removeFirst();
+      awaiter.completer.completeError(
+          new StateError(
+              'Stream was closed before ${awaiter.fillLength} byte(s) could be read.'),
+          awaiter.stackTrace);
+    }
+  }
+}
+
+class _ByteStreamReaderAwaiter {
+  final Completer<Uint8List> completer = new Completer<Uint8List>();
+  final StackTrace stackTrace;
+  final BytesBuilder builder = new BytesBuilder();
+  final int fillLength;
+
+  _ByteStreamReaderAwaiter(this.stackTrace, this.fillLength);
+
+  int get remaining => fillLength - builder.length;
+}

--- a/lib/src/byte_stream_reader.dart
+++ b/lib/src/byte_stream_reader.dart
@@ -18,13 +18,68 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
 
   ByteStreamReader({this.endian: Endian.big});
 
+  /// Read a signed, 8-bit integer.
+  Future<int> readInt8() => read(1).then((b) => b.readInt8());
+
+  /// Read a signed, 16-bit integer.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<int> readInt16([Endian endian]) =>
+      read(2, endian: endian ?? this.endian).then((b) => b.readInt16());
+
+  /// Read a signed, 32-bit integer.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<int> readInt32([Endian endian]) =>
+      read(4, endian: endian ?? this.endian).then((b) => b.readInt32());
+
+  /// Read a signed, 64-bit integer.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<int> readInt64([Endian endian]) =>
+      read(8, endian: endian ?? this.endian).then((b) => b.readInt64());
+
+  /// Read an unsigned, 8-bit integer.
+  Future<int> readUint8() => read(1).then((b) => b.readUint8());
+
+  /// Read an unsigned, 16-bit integer.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<int> readUint16([Endian endian]) =>
+      read(2, endian: endian ?? this.endian).then((b) => b.readUint16());
+
+  /// Read an unsigned, 32-bit integer.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<int> readUint32([Endian endian]) =>
+      read(4, endian: endian ?? this.endian).then((b) => b.readUint32());
+
+  /// Read an unsigned, 64-bit integer.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<int> readUint64([Endian endian]) =>
+      read(8, endian: endian ?? this.endian).then((b) => b.readUint64());
+
+  /// Read a 32-bit, floating-point number.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<double> readFloat32([Endian endian]) =>
+      read(4, endian: endian ?? this.endian).then((b) => b.readFloat32());
+
+  /// Read a 64-bit, floating-point number.
+  ///
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<double> readFloat64([Endian endian]) =>
+      read(8, endian: endian ?? this.endian).then((b) => b.readFloat64());
+
   /// Consumes a number of bytes from the input stream (see [consume]), then returns
   /// a single [ByteDataReader] that reads the received buffer.
-  /// 
+  ///
   /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
   Future<ByteDataReader> read(int length, {bool copy: false, Endian endian}) {
-    return consume(length).then(
-        (buf) => new ByteDataReader(endian: endian ?? this.endian, copy: copy)..add(buf));
+    return consume(length).then((buf) =>
+        new ByteDataReader(endian: endian ?? this.endian, copy: copy)
+          ..add(buf));
   }
 
   /// Consumes a number of bytes from the input stream (see [consume]), then adds the read data

--- a/lib/src/byte_stream_reader.dart
+++ b/lib/src/byte_stream_reader.dart
@@ -13,12 +13,18 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
       new DoubleLinkedQueue<_ByteStreamReaderAwaiter>();
   final Queue<Uint8List> _byteQueue = new DoubleLinkedQueue<Uint8List>();
 
+  /// An [Endian] that should be used to read data of length > 1 byte from the stream.
+  final Endian endian;
+
+  ByteStreamReader({this.endian: Endian.big});
+
   /// Consumes a number of bytes from the input stream (see [consume]), then returns
   /// a single [ByteDataReader] that reads the received buffer.
-  Future<ByteDataReader> read(int length,
-      {bool copy: false, Endian endian: Endian.big}) {
+  /// 
+  /// You may provide an [endian] value to override the property set on this instance (See [ByteStreamReader].endian).
+  Future<ByteDataReader> read(int length, {bool copy: false, Endian endian}) {
     return consume(length).then(
-        (buf) => new ByteDataReader(endian: endian, copy: copy)..add(buf));
+        (buf) => new ByteDataReader(endian: endian ?? this.endian, copy: copy)..add(buf));
   }
 
   /// Consumes a number of bytes from the input stream (see [consume]), then adds the read data

--- a/lib/src/byte_stream_reader.dart
+++ b/lib/src/byte_stream_reader.dart
@@ -103,6 +103,7 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
       int index = 0;
 
       // Complete any possible awaiters.
+      if (_awaiterQueue.isNotEmpty) print('Read $buf, q: $_awaiterQueue');
       while (_awaiterQueue.isNotEmpty && index < buf.length - 1) {
         var top = _awaiterQueue.first;
         //print(
@@ -215,4 +216,9 @@ class _ByteStreamReaderAwaiter {
   _ByteStreamReaderAwaiter(this.stackTrace, this.fillLength);
 
   int get remaining => fillLength - builder.length;
+
+  @override
+  String toString() {
+    return 'Awaiting $remaining/$fillLength';
+  }
 }

--- a/lib/src/byte_stream_reader.dart
+++ b/lib/src/byte_stream_reader.dart
@@ -103,15 +103,11 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
       int index = 0;
 
       // Complete any possible awaiters.
-      if (_awaiterQueue.isNotEmpty) print('Read $buf, q: $_awaiterQueue');
-      while (_awaiterQueue.isNotEmpty && index < buf.length - 1) {
+      while (_awaiterQueue.isNotEmpty && index <= buf.length - 1) {
         var top = _awaiterQueue.first;
-        //print(
-        //    'want ${top.remaining} from ${top.fillLength}; top: ${top.builder.toBytes()}, buf: $buf (${buf.hashCode})');
-        //print('buf as str: ${new String.fromCharCodes(buf)}');
-        //print('i = $index/${buf.length - 1}');
 
         // Dump out enqueued bytes into awaiters.
+
         while (_byteQueue.isNotEmpty && top.remaining > 0) {
           var topBytes = _byteQueue.removeFirst();
 
@@ -144,8 +140,6 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
 
         // If the buffer has >= the size, add the whole thing.
         else if (top.remaining >= buf.length) {
-          //print(
-          //    'Dumping all! ${buf.length} byte(s) into ${top.remaining}/${top.fillLength}!!');
           top.builder.add(buf);
 
           // Remove the awaiter if it's completed.
@@ -161,7 +155,6 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
         else {
           var out =
               new Uint8List.view(buf.buffer, buf.offsetInBytes, top.remaining);
-          //print('a awaiting ${top.remaining} from ${top.fillLength}; o: $out');
           index += top.remaining;
           top.builder.add(out);
 
@@ -169,7 +162,6 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
           if (top.remaining == 0) {
             _awaiterQueue.removeFirst();
             top.completer.complete(castBytes(top.builder.toBytes()));
-            //print('boom');
           } else {
             buf = new Uint8List.view(buf.buffer, buf.offsetInBytes + index);
           }
@@ -180,16 +172,12 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
                 new Uint8List.view(buf.buffer, buf.offsetInBytes + index);
             buf = leftover;
           }
-
-          //print('Index is now $index; buf is now $buf (${buf.hashCode})');
         }
       }
 
       // Enqueue all leftover data.
-      //print('Final i: $index');
       if (buf.isNotEmpty) {
         var leftover = buf;
-        //print('Leftover: $leftover (${new String.fromCharCodes(leftover)})');
         _byteQueue.addLast(leftover);
       }
     });

--- a/lib/src/byte_stream_reader.dart
+++ b/lib/src/byte_stream_reader.dart
@@ -13,6 +13,20 @@ class ByteStreamReader extends StreamConsumer<List<int>> {
       new DoubleLinkedQueue<_ByteStreamReaderAwaiter>();
   final Queue<Uint8List> _byteQueue = new DoubleLinkedQueue<Uint8List>();
 
+  /// Consumes a number of bytes from the input stream (see [consume]), then returns
+  /// a single [ByteDataReader] that reads the received buffer.
+  Future<ByteDataReader> read(int length,
+      {bool copy: false, Endian endian: Endian.big}) {
+    return consume(length).then(
+        (buf) => new ByteDataReader(endian: endian, copy: copy)..add(buf));
+  }
+
+  /// Consumes a number of bytes from the input stream (see [consume]), then adds the read data
+  /// into a [ByteDataReader].
+  Future<void> readInto(ByteDataReader reader, int length, {bool copy}) {
+    return consume(length).then((buf) => reader.add(buf, copy: copy));
+  }
+
   /// Returns a [Future] that completes with a buffer of the given size, read
   /// asynchronously from the incoming stream.
   Future<Uint8List> consume(int length) {

--- a/test/byte_stream_reader_test.dart
+++ b/test/byte_stream_reader_test.dart
@@ -17,25 +17,25 @@ void main() {
   });
 
   test('can read buffer of smaller size', () async {
-    expect(await reader.read(3), [$H, $e, $l]);
+    expect(await reader.consume(3), [$H, $e, $l]);
   });
 
   test('can read buffer of exact size', () async {
-    expect(await reader.read(7), [$H, $e, $l, $l, $o, $comma, $space]);
+    expect(await reader.consume(7), [$H, $e, $l, $l, $o, $comma, $space]);
   });
 
   test('can read buffer of greater size', () async {
-    expect(await reader.read(10),
+    expect(await reader.consume(10),
         [$H, $e, $l, $l, $o, $comma, $space, $w, $o, $r]);
   });
 
   test('fails on reads of too large a size', () async {
-    expect(() => reader.read(1000), throwsStateError);
+    expect(() => reader.consume(1000), throwsStateError);
   });
 
   test('subsequent reads', () async {
-    expect(await reader.read(3), [$H, $e, $l]);
-    expect(await reader.read(3), [$l, $o, $comma]);
+    expect(await reader.consume(3), [$H, $e, $l]);
+    expect(await reader.consume(3), [$l, $o, $comma]);
   });
 
   group('enqueued reads', () {
@@ -51,15 +51,15 @@ void main() {
 
     test('data added after listening', () async {
       var reader = new ByteStreamReader();
-      var f = reader.read(5);
+      var f = reader.consume(5);
       data.pipe(reader);
       expect(f, completion([$f, $o, $o, $b, $a]));
     });
 
     test('subsequent reads', () async {
       var reader = new ByteStreamReader();
-      var f = reader.read(2);
-      var g = reader.read(4);
+      var f = reader.consume(2);
+      var g = reader.consume(4);
       print('g should be ${[$o, $o, $b, $a]}');
       data.pipe(reader);
       expect(f, completion([$f, $o]));

--- a/test/byte_stream_reader_test.dart
+++ b/test/byte_stream_reader_test.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'package:buffer/buffer.dart';
+import 'package:charcode/ascii.dart';
+import 'package:test/test.dart';
+
+void main() {
+  ByteStreamReader reader;
+
+  setUp(() {
+    var stream = new Stream<List<int>>.fromIterable([
+      [$H, $e, $l, $l, $o, $comma, $space],
+      [$w, $o, $r, $l, $d, $exclamation],
+    ]);
+
+    reader = new ByteStreamReader();
+    stream.pipe(reader);
+  });
+
+  test('can read buffer of smaller size', () async {
+    expect(await reader.read(3), [$H, $e, $l]);
+  });
+
+  test('can read buffer of exact size', () async {
+    expect(await reader.read(7), [$H, $e, $l, $l, $o, $comma, $space]);
+  });
+
+  test('can read buffer of greater size', () async {
+    expect(await reader.read(10),
+        [$H, $e, $l, $l, $o, $comma, $space, $w, $o, $r]);
+  });
+
+  test('fails on reads of too large a size', () async {
+    expect(() => reader.read(1000), throwsStateError);
+  });
+
+  test('subsequent reads', () async {
+    expect(await reader.read(3), [$H, $e, $l]);
+    expect(await reader.read(3), [$l, $o, $comma]);
+  });
+
+  group('enqueued reads', () {
+    Stream<List<int>> data;
+
+    setUp(() {
+      data = new Stream<List<int>>.fromIterable([
+        [$f, $o, $o],
+        [$b, $a],
+        [$r],
+      ]);
+    });
+
+    test('data added after listening', () async {
+      var reader = new ByteStreamReader();
+      var f = reader.read(5);
+      data.pipe(reader);
+      expect(f, completion([$f, $o, $o, $b, $a]));
+    });
+
+    test('subsequent reads', () async {
+      var reader = new ByteStreamReader();
+      var f = reader.read(2);
+      var g = reader.read(4);
+      print('g should be ${[$o, $o, $b, $a]}');
+      data.pipe(reader);
+      expect(f, completion([$f, $o]));
+      expect(g, completion([$o, $b, $a, $r]));
+    });
+  });
+}

--- a/test/byte_stream_reader_test.dart
+++ b/test/byte_stream_reader_test.dart
@@ -56,7 +56,7 @@ void main() {
       expect(f, completion([$f, $o, $o, $b, $a]));
     });
 
-    test('subsequent reads', () async {
+    test('subsequent reads', () {
       var reader = new ByteStreamReader();
       var f = reader.consume(2);
       var g = reader.consume(4);


### PR DESCRIPTION
This class was originally `BinaryReader` in my previous attempt at a Cassandra package:
https://github.com/dart-community/cassandra/blob/master/lib/src/binary_reader.dart

I've updated it to use the infrastructure from `package:buffer`. It's essentially like `ByteDataReader`, but it reads asynchronously. It actually uses `ByteDataReader` under-the-hood, and so you can call async methods like `readUint8`, etc.

I've also included a set of unit tests.

```dart
import 'dart:async';
import 'dart:io';
import 'dart:typed_data';
import 'package:buffer/buffer.dart';

/// Parse a packet from some fictional protocol.
Future<Uint8List> getPayloadFrometworkPacket(Socket socket) async {
  // Pipe the stream into the [ByteStreamReader].
  var rdr = ByteStreamReader();
  socket.pipe(rdr);

  // Assume that in this protocol, every packet has a 12-byte header:
  // * 0: 1 byte indicating protocol version
  // * 1: Additional flags
  // * 2: 2-byte checksum = flags & version
  // * 4: 8 bytes that indicate the length of the rest of the packet (payload).

  // Let's read our data!.
  var protocolVersion = await rdr.readUint8();
  var flags = await rdr.readUint8();
  var checksum = await rdr.readUint16();

  // Validate the checksum.
  if (checksum != (protocolVersion & flags)) {
    throw FormatException(
        'Invalid checksum $checksum; expected ${protocolVersion & flags}.');
  }

  // Return the rest of the packet.
  var payloadLength = await rdr.readUint64();
  return await rdr.consume(payloadLength);
}
```