### PR TITLE
ByteDataReader: Expose the offset

### DIFF
--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -318,6 +318,7 @@ class ByteDataReader {
   ByteDataReader({this.endian = Endian.big, bool copy = false}) : _copy = copy;
 
   int get remainingLength => _queueTotalLength - _offset;
+  int get offset => _offset;
 
   void _clearQueue() {
     while (_queue.isNotEmpty && _queue.first.length == _offset) {


### PR DESCRIPTION
I've been re-implementing Git in Dart, and when reading the packfiles and index files, it's quite useful to know the current offset.