### PR TITLE
initial migration to null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-nullsafety.0
+## 1.1.0-nullsafety.0
 
 - Updated to nullsafety, no changes to external api
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.0
+
+- Updated to nullsafety, no changes to external api
+  
 ## 1.0.7
 
 - Updated to modern Dart standards.

--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -172,6 +172,7 @@ class ByteDataWriter {
   set _data(ByteData? data) {
     if (data == null) {
       _dataEmpty = true;
+      __data = ByteData(0);
       return;
     }
     __data = data;
@@ -329,6 +330,7 @@ class ByteDataReader {
   set _data(ByteData? data) {
     if (data == null) {
       _dataEmpty = true;
+      __data = ByteData(0);
       return;
     }
     __data = data;
@@ -351,7 +353,7 @@ class ByteDataReader {
       final first = _queue.removeFirst();
       _queueCurrentLength -= first.length;
       _offset = 0;
-      _dataEmpty = true;
+      _data = null;
     }
   }
 

--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -6,7 +6,7 @@ import 'dart:typed_data';
 /// Read [stream] into a String.
 ///
 /// Defaults to [utf8] if no [encoding] is given.
-Future<String> readAsString(Stream<List<int>> stream, {Encoding encoding}) {
+Future<String> readAsString(Stream<List<int>> stream, {Encoding? encoding}) {
   encoding ??= utf8;
   return encoding.decodeStream(stream);
 }
@@ -20,7 +20,7 @@ Future<String> readAsString(Stream<List<int>> stream, {Encoding encoding}) {
 /// (e.g. because the underlying list may get modified).
 Future<Uint8List> readAsBytes(
   Stream<List<int>> stream, {
-  int maxLength,
+  int? maxLength,
   bool copy = false,
 }) async {
   final bb = BytesBuffer();
@@ -44,7 +44,7 @@ Future<Uint8List> readAsBytes(
 Stream<Uint8List> sliceStream(
   Stream<List<int>> stream,
   int sliceLength, {
-  int maxLength,
+  int? maxLength,
   bool copy = false,
 }) async* {
   var total = 0;
@@ -62,7 +62,7 @@ Stream<Uint8List> sliceStream(
 
     while (getBL() >= sliceLength) {
       final bufferLength = getBL();
-      Uint8List overflow;
+      Uint8List? overflow;
       if (bufferLength > sliceLength) {
         final last = buffer.removeLast();
         final index = sliceLength - bufferLength + last.length;
@@ -130,7 +130,7 @@ class BytesBuffer {
   ///
   /// Set [copy] to true if [bytes] need to be copied (e.g. the underlying
   /// buffer will be modified.)
-  void add(List<int> bytes, {bool copy}) {
+  void add(List<int> bytes, {bool? copy}) {
     _chunks.add(castBytes(bytes, copy: copy ?? _copy));
     _length += bytes.length;
   }
@@ -141,7 +141,7 @@ class BytesBuffer {
   }
 
   /// Concatenate the byte arrays and return them as a single unit.
-  Uint8List toBytes({bool copy}) {
+  Uint8List toBytes({bool? copy}) {
     if (_chunks.length == 1 && !(copy ?? _copy)) {
       return _chunks.single;
     }
@@ -166,7 +166,7 @@ class ByteDataWriter {
   int bufferLength;
   final Endian endian;
   final _bb = BytesBuffer();
-  ByteData _data;
+  ByteData? _data;
   int _offset = 0;
 
   ByteDataWriter({this.bufferLength = 128, this.endian = Endian.big});
@@ -174,7 +174,7 @@ class ByteDataWriter {
   void _flush() {
     if (_data != null) {
       if (_offset > 0) {
-        _bb.add(_data.buffer.asUint8List(0, _offset));
+        _bb.add(_data!.buffer.asUint8List(0, _offset));
       }
       _data = null;
       _offset = 0;
@@ -182,7 +182,7 @@ class ByteDataWriter {
   }
 
   void _init(int required) {
-    if (_data == null || _offset + required > _data.lengthInBytes) {
+    if (_data == null || _offset + required > _data!.lengthInBytes) {
       _flush();
       _data = ByteData(bufferLength > required ? bufferLength : required);
     }
@@ -194,43 +194,43 @@ class ByteDataWriter {
     _bb.add(bytes, copy: copy);
   }
 
-  void writeFloat32(double value, [Endian endian]) {
+  void writeFloat32(double value, [Endian? endian]) {
     _init(4);
-    _data.setFloat32(_offset, value, endian ?? this.endian);
+    _data!.setFloat32(_offset, value, endian ?? this.endian);
     _offset += 4;
   }
 
-  void writeFloat64(double value, [Endian endian]) {
+  void writeFloat64(double value, [Endian? endian]) {
     _init(8);
-    _data.setFloat64(_offset, value, endian ?? this.endian);
+    _data!.setFloat64(_offset, value, endian ?? this.endian);
     _offset += 8;
   }
 
   void writeInt8(int value) {
     _init(1);
-    _data.setInt8(_offset, value);
+    _data!.setInt8(_offset, value);
     _offset++;
   }
 
-  void writeInt16(int value, [Endian endian]) {
+  void writeInt16(int value, [Endian? endian]) {
     _init(2);
-    _data.setInt16(_offset, value, endian ?? this.endian);
+    _data!.setInt16(_offset, value, endian ?? this.endian);
     _offset += 2;
   }
 
-  void writeInt32(int value, [Endian endian]) {
+  void writeInt32(int value, [Endian? endian]) {
     _init(4);
-    _data.setInt32(_offset, value, endian ?? this.endian);
+    _data!.setInt32(_offset, value, endian ?? this.endian);
     _offset += 4;
   }
 
-  void writeInt64(int value, [Endian endian]) {
+  void writeInt64(int value, [Endian? endian]) {
     _init(8);
-    _data.setInt64(_offset, value, endian ?? this.endian);
+    _data!.setInt64(_offset, value, endian ?? this.endian);
     _offset += 8;
   }
 
-  void writeInt(int byteLength, int value, [Endian endian]) {
+  void writeInt(int byteLength, int value, [Endian? endian]) {
     switch (byteLength) {
       case 1:
         writeInt8(value);
@@ -252,29 +252,29 @@ class ByteDataWriter {
 
   void writeUint8(int value) {
     _init(1);
-    _data.setUint8(_offset, value);
+    _data!.setUint8(_offset, value);
     _offset++;
   }
 
-  void writeUint16(int value, [Endian endian]) {
+  void writeUint16(int value, [Endian? endian]) {
     _init(2);
-    _data.setUint16(_offset, value, endian ?? this.endian);
+    _data!.setUint16(_offset, value, endian ?? this.endian);
     _offset += 2;
   }
 
-  void writeUint32(int value, [Endian endian]) {
+  void writeUint32(int value, [Endian? endian]) {
     _init(4);
-    _data.setUint32(_offset, value, endian ?? this.endian);
+    _data!.setUint32(_offset, value, endian ?? this.endian);
     _offset += 4;
   }
 
-  void writeUint64(int value, [Endian endian]) {
+  void writeUint64(int value, [Endian? endian]) {
     _init(8);
-    _data.setUint64(_offset, value, endian ?? this.endian);
+    _data!.setUint64(_offset, value, endian ?? this.endian);
     _offset += 8;
   }
 
-  void writeUint(int byteLength, int value, [Endian endian]) {
+  void writeUint(int byteLength, int value, [Endian? endian]) {
     switch (byteLength) {
       case 1:
         writeUint8(value);
@@ -312,8 +312,8 @@ class ByteDataReader {
   int _offset = 0;
   int _queueCurrentLength = 0;
   int _queueTotalLength = 0;
-  ByteData _data;
-  Completer _readAheadCompleter;
+  ByteData? _data;
+  Completer? _readAheadCompleter;
   int _readAheadRequired = 0;
 
   ByteDataReader({this.endian = Endian.big, bool copy = false}) : _copy = copy;
@@ -358,12 +358,12 @@ class ByteDataReader {
     _data ??= ByteData.view(_queue.first.buffer, _queue.first.offsetInBytes);
   }
 
-  void add(List<int> bytes, {bool copy}) {
+  void add(List<int> bytes, {bool? copy}) {
     _queue.add(castBytes(bytes, copy: copy ?? _copy));
     _queueCurrentLength += bytes.length;
     _queueTotalLength += bytes.length;
     if (_readAheadCompleter != null && remainingLength >= _readAheadRequired) {
-      _readAheadCompleter.complete();
+      _readAheadCompleter!.complete();
       _readAheadCompleter = null;
     }
   }
@@ -374,17 +374,17 @@ class ByteDataReader {
       return Future.value();
     }
     if (_readAheadCompleter != null && _readAheadRequired == length) {
-      return _readAheadCompleter.future;
+      return _readAheadCompleter!.future;
     }
     if (_readAheadCompleter != null && _readAheadRequired != length) {
       throw StateError('A different readAhead is already waiting.');
     }
     _readAheadRequired = length;
     _readAheadCompleter = Completer();
-    return _readAheadCompleter.future;
+    return _readAheadCompleter!.future;
   }
 
-  Uint8List read(int length, {bool copy}) {
+  Uint8List read(int length, {bool? copy}) {
     if (_queue.isEmpty || _queueCurrentLength - _offset < length) {
       throw StateError('Not enough bytes to read.');
     }
@@ -419,49 +419,49 @@ class ByteDataReader {
     return bb.toBytes();
   }
 
-  double readFloat32([Endian endian]) {
+  double readFloat32([Endian? endian]) {
     _init(4);
-    final value = _data.getFloat32(_offset, endian ?? this.endian);
+    final value = _data!.getFloat32(_offset, endian ?? this.endian);
     _offset += 4;
     return value;
   }
 
-  double readFloat64([Endian endian]) {
+  double readFloat64([Endian? endian]) {
     _init(8);
-    final value = _data.getFloat64(_offset, endian ?? this.endian);
+    final value = _data!.getFloat64(_offset, endian ?? this.endian);
     _offset += 8;
     return value;
   }
 
   int readInt8() {
     _init(1);
-    final value = _data.getInt8(_offset);
+    final value = _data!.getInt8(_offset);
     _offset += 1;
     return value;
   }
 
-  int readInt16([Endian endian]) {
+  int readInt16([Endian? endian]) {
     _init(2);
-    final value = _data.getInt16(_offset, endian ?? this.endian);
+    final value = _data!.getInt16(_offset, endian ?? this.endian);
     _offset += 2;
     return value;
   }
 
-  int readInt32([Endian endian]) {
+  int readInt32([Endian? endian]) {
     _init(4);
-    final value = _data.getInt32(_offset, endian ?? this.endian);
+    final value = _data!.getInt32(_offset, endian ?? this.endian);
     _offset += 4;
     return value;
   }
 
-  int readInt64([Endian endian]) {
+  int readInt64([Endian? endian]) {
     _init(8);
-    final value = _data.getInt64(_offset, endian ?? this.endian);
+    final value = _data!.getInt64(_offset, endian ?? this.endian);
     _offset += 8;
     return value;
   }
 
-  int readInt(int byteLength, [Endian endian]) {
+  int readInt(int byteLength, [Endian? endian]) {
     switch (byteLength) {
       case 1:
         return readInt8();
@@ -479,33 +479,33 @@ class ByteDataReader {
 
   int readUint8() {
     _init(1);
-    final value = _data.getUint8(_offset);
+    final value = _data!.getUint8(_offset);
     _offset += 1;
     return value;
   }
 
-  int readUint16([Endian endian]) {
+  int readUint16([Endian? endian]) {
     _init(2);
-    final value = _data.getUint16(_offset, endian ?? this.endian);
+    final value = _data!.getUint16(_offset, endian ?? this.endian);
     _offset += 2;
     return value;
   }
 
-  int readUint32([Endian endian]) {
+  int readUint32([Endian? endian]) {
     _init(4);
-    final value = _data.getUint32(_offset, endian ?? this.endian);
+    final value = _data!.getUint32(_offset, endian ?? this.endian);
     _offset += 4;
     return value;
   }
 
-  int readUint64([Endian endian]) {
+  int readUint64([Endian? endian]) {
     _init(8);
-    final value = _data.getUint64(_offset, endian ?? this.endian);
+    final value = _data!.getUint64(_offset, endian ?? this.endian);
     _offset += 8;
     return value;
   }
 
-  int readUint(int byteLength, [Endian endian]) {
+  int readUint(int byteLength, [Endian? endian]) {
     switch (byteLength) {
       case 1:
         return readUint8();

--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -166,15 +166,26 @@ class ByteDataWriter {
   int bufferLength;
   final Endian endian;
   final _bb = BytesBuffer();
-  ByteData? _data;
+  bool _dataEmpty = true;
+  ByteData __data = ByteData(0);
+  ByteData get _data => __data;
+  set _data(ByteData? data) {
+    if (data == null) {
+      _dataEmpty = true;
+      return;
+    }
+    __data = data;
+    _dataEmpty = false;
+  }
+
   int _offset = 0;
 
   ByteDataWriter({this.bufferLength = 128, this.endian = Endian.big});
 
   void _flush() {
-    if (_data != null) {
+    if (!_dataEmpty) {
       if (_offset > 0) {
-        _bb.add(_data!.buffer.asUint8List(0, _offset));
+        _bb.add(_data.buffer.asUint8List(0, _offset));
       }
       _data = null;
       _offset = 0;
@@ -182,7 +193,7 @@ class ByteDataWriter {
   }
 
   void _init(int required) {
-    if (_data == null || _offset + required > _data!.lengthInBytes) {
+    if (_dataEmpty || _offset + required > _data.lengthInBytes) {
       _flush();
       _data = ByteData(bufferLength > required ? bufferLength : required);
     }
@@ -196,37 +207,37 @@ class ByteDataWriter {
 
   void writeFloat32(double value, [Endian? endian]) {
     _init(4);
-    _data!.setFloat32(_offset, value, endian ?? this.endian);
+    _data.setFloat32(_offset, value, endian ?? this.endian);
     _offset += 4;
   }
 
   void writeFloat64(double value, [Endian? endian]) {
     _init(8);
-    _data!.setFloat64(_offset, value, endian ?? this.endian);
+    _data.setFloat64(_offset, value, endian ?? this.endian);
     _offset += 8;
   }
 
   void writeInt8(int value) {
     _init(1);
-    _data!.setInt8(_offset, value);
+    _data.setInt8(_offset, value);
     _offset++;
   }
 
   void writeInt16(int value, [Endian? endian]) {
     _init(2);
-    _data!.setInt16(_offset, value, endian ?? this.endian);
+    _data.setInt16(_offset, value, endian ?? this.endian);
     _offset += 2;
   }
 
   void writeInt32(int value, [Endian? endian]) {
     _init(4);
-    _data!.setInt32(_offset, value, endian ?? this.endian);
+    _data.setInt32(_offset, value, endian ?? this.endian);
     _offset += 4;
   }
 
   void writeInt64(int value, [Endian? endian]) {
     _init(8);
-    _data!.setInt64(_offset, value, endian ?? this.endian);
+    _data.setInt64(_offset, value, endian ?? this.endian);
     _offset += 8;
   }
 
@@ -252,25 +263,25 @@ class ByteDataWriter {
 
   void writeUint8(int value) {
     _init(1);
-    _data!.setUint8(_offset, value);
+    _data.setUint8(_offset, value);
     _offset++;
   }
 
   void writeUint16(int value, [Endian? endian]) {
     _init(2);
-    _data!.setUint16(_offset, value, endian ?? this.endian);
+    _data.setUint16(_offset, value, endian ?? this.endian);
     _offset += 2;
   }
 
   void writeUint32(int value, [Endian? endian]) {
     _init(4);
-    _data!.setUint32(_offset, value, endian ?? this.endian);
+    _data.setUint32(_offset, value, endian ?? this.endian);
     _offset += 4;
   }
 
   void writeUint64(int value, [Endian? endian]) {
     _init(8);
-    _data!.setUint64(_offset, value, endian ?? this.endian);
+    _data.setUint64(_offset, value, endian ?? this.endian);
     _offset += 8;
   }
 
@@ -312,7 +323,18 @@ class ByteDataReader {
   int _offset = 0;
   int _queueCurrentLength = 0;
   int _queueTotalLength = 0;
-  ByteData? _data;
+  bool _dataEmpty = true;
+  ByteData __data = ByteData(0);
+  ByteData get _data => __data;
+  set _data(ByteData? data) {
+    if (data == null) {
+      _dataEmpty = true;
+      return;
+    }
+    __data = data;
+    _dataEmpty = false;
+  }
+
   Completer? _readAheadCompleter;
   int _readAheadRequired = 0;
 
@@ -329,7 +351,7 @@ class ByteDataReader {
       final first = _queue.removeFirst();
       _queueCurrentLength -= first.length;
       _offset = 0;
-      _data = null;
+      _dataEmpty = true;
     }
   }
 
@@ -355,7 +377,9 @@ class ByteDataReader {
       _queue.addFirst(merged);
       _data = null;
     }
-    _data ??= ByteData.view(_queue.first.buffer, _queue.first.offsetInBytes);
+    if (_dataEmpty) {
+      _data = ByteData.view(_queue.first.buffer, _queue.first.offsetInBytes);
+    }
   }
 
   void add(List<int> bytes, {bool? copy}) {
@@ -421,42 +445,42 @@ class ByteDataReader {
 
   double readFloat32([Endian? endian]) {
     _init(4);
-    final value = _data!.getFloat32(_offset, endian ?? this.endian);
+    final value = _data.getFloat32(_offset, endian ?? this.endian);
     _offset += 4;
     return value;
   }
 
   double readFloat64([Endian? endian]) {
     _init(8);
-    final value = _data!.getFloat64(_offset, endian ?? this.endian);
+    final value = _data.getFloat64(_offset, endian ?? this.endian);
     _offset += 8;
     return value;
   }
 
   int readInt8() {
     _init(1);
-    final value = _data!.getInt8(_offset);
+    final value = _data.getInt8(_offset);
     _offset += 1;
     return value;
   }
 
   int readInt16([Endian? endian]) {
     _init(2);
-    final value = _data!.getInt16(_offset, endian ?? this.endian);
+    final value = _data.getInt16(_offset, endian ?? this.endian);
     _offset += 2;
     return value;
   }
 
   int readInt32([Endian? endian]) {
     _init(4);
-    final value = _data!.getInt32(_offset, endian ?? this.endian);
+    final value = _data.getInt32(_offset, endian ?? this.endian);
     _offset += 4;
     return value;
   }
 
   int readInt64([Endian? endian]) {
     _init(8);
-    final value = _data!.getInt64(_offset, endian ?? this.endian);
+    final value = _data.getInt64(_offset, endian ?? this.endian);
     _offset += 8;
     return value;
   }
@@ -479,28 +503,28 @@ class ByteDataReader {
 
   int readUint8() {
     _init(1);
-    final value = _data!.getUint8(_offset);
+    final value = _data.getUint8(_offset);
     _offset += 1;
     return value;
   }
 
   int readUint16([Endian? endian]) {
     _init(2);
-    final value = _data!.getUint16(_offset, endian ?? this.endian);
+    final value = _data.getUint16(_offset, endian ?? this.endian);
     _offset += 2;
     return value;
   }
 
   int readUint32([Endian? endian]) {
     _init(4);
-    final value = _data!.getUint32(_offset, endian ?? this.endian);
+    final value = _data.getUint32(_offset, endian ?? this.endian);
     _offset += 4;
     return value;
   }
 
   int readUint64([Endian? endian]) {
     _init(8);
-    final value = _data!.getUint64(_offset, endian ?? this.endian);
+    final value = _data.getUint64(_offset, endian ?? this.endian);
     _offset += 8;
     return value;
   }

--- a/lib/io_buffer.dart
+++ b/lib/io_buffer.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 /// - List<int> (memory buffer)
 /// - File (will call openRead())
 /// - String (will call utf8.encode())
-Stream<List<int>> openBytesStream(
+Stream<List<int>>? openBytesStream(
     /* String | List<int> | File | Stream<List<int>> */ source) {
   if (source == null) {
     return null;

--- a/lib/io_buffer.dart
+++ b/lib/io_buffer.dart
@@ -7,11 +7,9 @@ import 'dart:io';
 /// - List<int> (memory buffer)
 /// - File (will call openRead())
 /// - String (will call utf8.encode())
-Stream<List<int>>? openBytesStream(
-    /* String | List<int> | File | Stream<List<int>> */ source) {
-  if (source == null) {
-    return null;
-  } else if (source is Stream<List<int>>) {
+Stream<List<int>> openBytesStream(
+    /* String | List<int> | File | Stream<List<int>> */ Object source) {
+  if (source is Stream<List<int>>) {
     return source;
   } else if (source is List<int>) {
     return Stream.fromFuture(Future.value(source));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: buffer
 description: >
   Utility functions and classes to work with byte buffers and streams efficiently,
   to read and write binary data formats.
-version: 2.0.0-nullsafety.0
+version: 1.1.0-nullsafety.0
 homepage: https://github.com/isoos/buffer
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,15 +2,15 @@ name: buffer
 description: >
   Utility functions and classes to work with byte buffers and streams efficiently,
   to read and write binary data formats.
-version: 1.0.7
+version: 2.0.0-nullsafety.0
 homepage: https://github.com/isoos/buffer
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 #dependencies:
 #  path: ^1.4.1
 
 dev_dependencies:
-  pedantic: ^1.0.0
-  test: ^1.0.0
+  pedantic: ^1.10.0-nullsafety.3
+  test: ^1.16.0-nullsafety.10


### PR DESCRIPTION
Hi, here is the null-safety migration to address #5 

All of the optional parameters you were already checking for null and using a reasonable default. So no issues there on the public api side of things.

As far as asserts. There are no more asserts than previously. (Since prior to null-safety all receivers were checked). But there are more non-null casts via `!` than I think you probably want. Most have to deal with the `ByteData _data` buffer in the `ByteDataReader` and `ByteDataWriter`. Currently you set it as null after flush to indicate that the data has been flushed, and needs to be reinitialized. Maybe an alternative could be to have a boolean for that condition, and always have the `ByteData` not be null. Or would checking if the offset is zero have the same effect? 

One change that you could make to the public api is in the `io_buffer.dart` file making the return type non-nullable for `openBytesStream` and accepting a non-nullable `Object` as the parameter. Let me know if that is something that you'd like me to change.