### PR TITLE
Fixed bug related to zero byte read at end of buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Bug fix. No changes to external API.
+
 ## 1.1.0
 
 - Final null-safe release.

--- a/lib/buffer.dart
+++ b/lib/buffer.dart
@@ -411,6 +411,9 @@ class ByteDataReader {
   }
 
   Uint8List read(int length, {bool? copy}) {
+    if (length == 0) {
+      return Uint8List(0);
+    }
     if (_queue.isEmpty || _queueCurrentLength - _offset < length) {
       throw StateError('Not enough bytes to read.');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: buffer
 description: >
   Utility functions and classes to work with byte buffers and streams efficiently,
   to read and write binary data formats.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/isoos/buffer
 
 environment:

--- a/test/read_write_test.dart
+++ b/test/read_write_test.dart
@@ -106,5 +106,15 @@ void main() {
         expect(reader.offsetInBytes, expected);
       }
     });
+
+    // See https://github.com/isoos/buffer/issues/7
+    test('read zero bytes from end of buffer', () {
+      final reader = ByteDataReader();
+      reader.add([0,0,0,0]);
+      final strLen = reader.readUint32();
+      expect(strLen, equals(0));
+      var noBytes = reader.read(strLen);
+      expect(noBytes.length, equals(0));
+    });
   });
 }


### PR DESCRIPTION
This addresses issue isoos#7 by simply returning UInt8List(0) from read when requested read length is 0. Also added a test that demonstrates the problem and the validity of this fix. pubspec.yaml and CHANGELOG.md are updated for a new 1.1.1 release.